### PR TITLE
Change GetTargets Copy Strategy

### DIFF
--- a/src/main/java/org/photonvision/PhotonPipelineResult.java
+++ b/src/main/java/org/photonvision/PhotonPipelineResult.java
@@ -20,7 +20,6 @@ package org.photonvision;
 import edu.wpi.first.wpilibj.DriverStation;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -108,9 +107,7 @@ public class PhotonPipelineResult {
    * @return A copy of the vector of targets.
    */
   public List<PhotonTrackedTarget> getTargets() {
-    List<PhotonTrackedTarget> r = new ArrayList<>(targets.size());
-    Collections.copy(r, targets);
-    return r;
+    return new ArrayList<PhotonTrackedTarget>(targets);
   }
 
   @Override

--- a/src/main/java/org/photonvision/PhotonPipelineResult.java
+++ b/src/main/java/org/photonvision/PhotonPipelineResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Photon Vision.
+ * Copyright (C) 2020-2021 Photon Vision.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Previous strategy was throwing exceptions - replaced with a reasonable alternate.

![image](https://user-images.githubusercontent.com/4583662/103469506-5b8f9100-4d2b-11eb-9cf3-aab4390d421b.png)

![image](https://user-images.githubusercontent.com/4583662/103469509-621e0880-4d2b-11eb-9072-030a36982acd.png)

Reference: https://stackoverflow.com/questions/689370/how-to-copy-java-collections-list

It appears with `Collections.copy()`, we'd have to instantiate each member ourselves? The change seems to be the more succinct way to do this.